### PR TITLE
Remove all non-essential field remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export const Session = model({
     expiresAt: date({ required: true }),
     ipAddress: string(),
     token: string({ required: true, unique: true }),
-    user: link({ required: true, target: 'user' }),
+    userId: link({ required: true, target: 'user' }),
     userAgent: string(),
   },
 });
@@ -80,7 +80,7 @@ export const Account = model({
     refreshToken: string(),
     refreshTokenExpiresAt: date(),
     scope: string(),
-    user: link({ required: true, target: 'user' }),
+    userId: link({ required: true, target: 'user' }),
   },
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export const ronin = (client?: SyntaxFactory): AdapterInstance => {
       create: async ({ data, model }) => {
         const transformed = await transformInput(data, model);
         const record = await factory.add[model].with<ResultRecordBase<Date>>(transformed);
-        return transformOutput(record, model);
+        return transformOutput(record);
       },
       delete: async ({ model, where = [] }) => {
         const instructions = convertWhereClause(where);
@@ -113,14 +113,14 @@ export const ronin = (client?: SyntaxFactory): AdapterInstance => {
           with: transformed,
         });
 
-        return results.map((result) => transformOutput(result, slug));
+        return results.map((result) => transformOutput(result));
       },
       findOne: async ({ model, where }) => {
         const instructions = convertWhereClause(where);
         const result = await factory.get[model].with<ResultRecordBase<Date> | null>(
           instructions,
         );
-        return transformOutput(result, model);
+        return transformOutput(result);
       },
       update: async ({ model, update, where = [] }) => {
         const instructions = convertWhereClause(where);
@@ -129,7 +129,7 @@ export const ronin = (client?: SyntaxFactory): AdapterInstance => {
           with: instructions,
           to: transformed as Record<string, unknown>,
         });
-        return transformOutput(result, model);
+        return transformOutput(result);
       },
       updateMany: async ({ model: slug, update, where = [] }) => {
         const model = await getModel(factory, slug);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -189,7 +189,6 @@ export const transformOrderedBy = (sortBy?: {
  */
 export const transformOutput = (
   data: ResultRecordBase<Date> | null,
-  model: string,
 ): Record<string, unknown> | null => {
   if (!data || data === null) return null;
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -96,9 +96,6 @@ export const getModel = async (
 /**
  * Transforms a provided inout data or query & converts it to RONIN query instructions.
  *
- * The primary purpose of thos transformer is that some fields of Better Auth require
- * remapping. Such as `userId` to `user` for the `account` and `session` models, etc.
- *
  * @param data - The data to be transformed.
  * @param model - The model to be used for the transformation.
  *
@@ -126,13 +123,6 @@ export const transformInput = async <
     });
 
   for (const [key, value] of Object.entries(values)) {
-    // We recommend customers use `user` instead of `userId` for their account & session
-    // model fields. As such, we need to remap this field to `userId` for the RONIN query.
-    if (key === 'userId' && ['account', 'session'].includes(model)) {
-      properties.set('user', value);
-      continue;
-    }
-
     // When signing in / up with OAuth we can be provided a URL string as a link to an
     // image for a user. As such, we need to pull this image so we can provide it as a
     // `Blob` to RONIN when creating the user.
@@ -213,17 +203,6 @@ export const transformOutput = (
 
   for (const [key, value] of Object.entries(values)) {
     properties.set(key, value);
-
-    switch (model) {
-      case 'account':
-      case 'session': {
-        if (key === 'user') {
-          properties.set('userId', value);
-          properties.delete('user');
-        }
-        break;
-      }
-    }
   }
 
   return Object.fromEntries(properties);

--- a/tests/fixtures/schema.ts
+++ b/tests/fixtures/schema.ts
@@ -19,7 +19,7 @@ export const Session = model({
     expiresAt: date({ required: true }),
     ipAddress: string(),
     token: string({ required: true, unique: true }),
-    user: link({
+    userId: link({
       required: true,
       target: 'user',
     }),
@@ -40,7 +40,7 @@ export const Account = model({
     refreshToken: string(),
     refreshTokenExpiresAt: date(),
     scope: string(),
-    user: link({
+    userId: link({
       required: true,
       target: 'user',
     }),

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -669,7 +669,7 @@ describe('transform', () => {
 
   describe('transformOutput', () => {
     test('with `null` data', () => {
-      const transformed = transformOutput(null, 'account');
+      const transformed = transformOutput(null);
       expect(transformed).toBeDefined();
       expect(transformed).toBe(null);
     });
@@ -679,7 +679,7 @@ describe('transform', () => {
 
       const { user } = await auth.api.signUpEmail({ body: TEST_USER });
       const account = await client.get.account.with.userId(user.id);
-      const transformed = transformOutput(account, 'account');
+      const transformed = transformOutput(account);
 
       expect(account).toBeDefined();
       expect(account).toMatchObject({
@@ -725,7 +725,7 @@ describe('transform', () => {
 
       const { token } = await auth.api.signUpEmail({ body: TEST_USER });
       const session = await client.get.session.with.token(token as string);
-      const transformed = transformOutput(session, 'session');
+      const transformed = transformOutput(session);
 
       expect(session).toBeDefined();
       expect(session).toMatchObject({
@@ -761,7 +761,7 @@ describe('transform', () => {
 
       const signUp = await auth.api.signUpEmail({ body: TEST_USER });
       const user = await client.get.user.with.id(signUp.user.id);
-      const transformed = transformOutput(user, 'user');
+      const transformed = transformOutput(user);
 
       expect(user).toBeDefined();
       expect(user).toMatchObject({
@@ -793,18 +793,15 @@ describe('transform', () => {
     // TODO(@nurodev): Add `verification` test
 
     test('with an unknown record', () => {
-      const transformed = transformOutput(
-        {
-          id: 'usr_1234',
-          ronin: {
-            createdAt: new Date(),
-            createdBy: null,
-            updatedAt: new Date(),
-            updatedBy: null,
-          },
+      const transformed = transformOutput({
+        id: 'usr_1234',
+        ronin: {
+          createdAt: new Date(),
+          createdBy: null,
+          updatedAt: new Date(),
+          updatedBy: null,
         },
-        'foobar',
-      );
+      });
 
       expect(transformed).toBeDefined();
       expect(transformed).toMatchObject({

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -358,7 +358,7 @@ describe('transform', () => {
             createdAt: instructions.createdAt,
             updatedAt: instructions.updatedAt,
           },
-          user: instructions.userId,
+          userId: instructions.userId,
         });
       });
 
@@ -384,7 +384,7 @@ describe('transform', () => {
             updatedAt: instructions.updatedAt,
           },
           token: instructions.token,
-          user: instructions.userId,
+          userId: instructions.userId,
           userAgent: '',
         });
       });
@@ -603,7 +603,7 @@ describe('transform', () => {
             createdAt: instruction.createdAt,
             updatedAt: instruction.updatedAt,
           },
-          user: instruction.userId,
+          userId: instruction.userId,
         },
       ]);
     });
@@ -678,7 +678,7 @@ describe('transform', () => {
       const { auth, client } = await init();
 
       const { user } = await auth.api.signUpEmail({ body: TEST_USER });
-      const account = await client.get.account.with.user(user.id);
+      const account = await client.get.account.with.userId(user.id);
       const transformed = transformOutput(account, 'account');
 
       expect(account).toBeDefined();
@@ -699,7 +699,7 @@ describe('transform', () => {
         refreshToken: null,
         refreshTokenExpiresAt: null,
         scope: null,
-        user: expect.any(String),
+        userId: expect.any(String),
       });
 
       expect(transformed).toBeDefined();
@@ -739,7 +739,7 @@ describe('transform', () => {
         expiresAt: expect.any(Date),
         ipAddress: '',
         token: expect.any(String),
-        user: expect.any(String),
+        userId: expect.any(String),
         userAgent: '',
       });
 


### PR DESCRIPTION
As part of the initial release of this adapter we provided our own logic to handle the remapping of certain fields, such as `userId` to `user` for cleaner schema structure.

However, as complexity has grown it makes more sense to not encourage or support this behaviour and instead recommend users follow or copy the exact schemas provided by Better Auth.